### PR TITLE
Check for CanBeUsedWithWeapon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ bld/
 # Visual Studio 2017 auto generated files
 Generated\ Files/
 
+# JetBrains
+.idea
+
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*

--- a/State/SkillDictionary.cs
+++ b/State/SkillDictionary.cs
@@ -41,6 +41,7 @@ public class SkillDictionary
                 .DistinctBy(x => x.Name, StringComparer.OrdinalIgnoreCase)
                 .Select(x => new SkillInfo(true, x.Name,
                     x.CanBeUsed &&
+                    x.CanBeUsedWithWeapon &&
                     x.Cost <= currentManaPool &&
                     x.GetStat(GameStat.LifeCost) < currentHpPool,
                     x.GetStat(GameStat.LifeCost),


### PR DESCRIPTION
`CanBeUsed` for Skills is returning True, when you are using an incorrect weapon.

This change ensures that `CanBeUsedWithWeapon` is checked before returning` CanBeUsed`.