### PR TITLE
Added IsChatOpen check to PressKeySideEffect

### DIFF
--- a/SideEffects/PressKeySideEffect.cs
+++ b/SideEffects/PressKeySideEffect.cs
@@ -10,7 +10,7 @@ public record PressKeySideEffect(Keys Key) : ISideEffect
 {
     public SideEffectApplicationResult Apply(RuleState state)
     {
-        if (!state.InternalState.CanPressKey)
+        if (!state.InternalState.CanPressKey || state.IsChatOpen)
         {
             return SideEffectApplicationResult.UnableToApply;
         }


### PR DESCRIPTION
Added IsChatOpen check to PressKeySideEffect as default -> will not press any keys if chat is open without having to specify 
"!IsChatOpen" in every rule. (I don't see a reason one would ever want ReAgent to press keys when chat is open) 